### PR TITLE
Fix link from https://www.openscapes.org/champions/ to blog

### DIFF
--- a/content/champions.md
+++ b/content/champions.md
@@ -5,7 +5,7 @@ keywords = ["FAQ","How do I","questions","what if"]
 +++
 
 
-**Openscapes Champions is an open data science mentorship program for science teams.** We support researchers to reimagine data analysis & stewardship as a collaborative effort, develop modern skills that are of immediate value to them, and cultivate collaborative and inclusive research communities. We work with academic, government, and non-profit research teams who become part of the open science movement as Champions empowered with new skillsets and mindsets for modern data-intensive science. Learn these Champions' stories through our [blog](/blog/tags/case-study/), [media](/media), as well as steps for you to [supercharge your research](https://www.nature.com/articles/d41586-019-03335-4). 
+**Openscapes Champions is an open data science mentorship program for science teams.** We support researchers to reimagine data analysis & stewardship as a collaborative effort, develop modern skills that are of immediate value to them, and cultivate collaborative and inclusive research communities. We work with academic, government, and non-profit research teams who become part of the open science movement as Champions empowered with new skillsets and mindsets for modern data-intensive science. Learn these Champions' stories through our [blog](/blog/), [media](/media), as well as steps for you to [supercharge your research](https://www.nature.com/articles/d41586-019-03335-4). 
 
 <br>
 


### PR DESCRIPTION
I just found a broken link on https://www.openscapes.org/champions/, I'm not sure whether the proposed fix works, but this would be consistent with the link to media.